### PR TITLE
Add animations to dialog

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,18 +1,19 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                xmlns:tools="http://schemas.android.com/tools"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:paddingLeft="@dimen/activity_horizontal_margin"
-                android:paddingRight="@dimen/activity_horizontal_margin"
-                android:paddingTop="@dimen/activity_vertical_margin"
-                android:paddingBottom="@dimen/activity_vertical_margin"
-                android:background="@android:color/white"
-                tools:context=".MainActivity">
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/white"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    tools:context=".MainActivity">
 
     <Button
         android:id="@+id/button"
-        android:text="@string/hello_world"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"/>
+        android:layout_height="wrap_content"
+        android:text="@string/hello_world"/>
 
 </RelativeLayout>

--- a/dialogplus/src/main/res/anim/slide_in.xml
+++ b/dialogplus/src/main/res/anim/slide_in.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+     android:shareInterpolator="false">
+
+    <translate
+        android:duration="300"
+        android:fromXDelta="0%"
+        android:toXDelta="0%"
+        android:fromYDelta="100%"
+        android:toYDelta="0%"/>
+</set>

--- a/dialogplus/src/main/res/anim/slide_out.xml
+++ b/dialogplus/src/main/res/anim/slide_out.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+     android:shareInterpolator="false">
+
+    <translate
+        android:duration="300"
+        android:fromXDelta="0%"
+        android:toXDelta="0%"
+        android:fromYDelta="0%"
+        android:toYDelta="100%"/>
+</set>

--- a/dialogplus/src/main/res/layout/base_container.xml
+++ b/dialogplus/src/main/res/layout/base_container.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-
 <LinearLayout
     android:id="@+id/outmost_container"
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="match_parent"
     android:background="@color/black_overlay"
+    android:clickable="true"
     android:orientation="vertical">
 
     <View

--- a/dialogplus/src/main/res/values/colors.xml
+++ b/dialogplus/src/main/res/values/colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="card_shadow">#D4D4D4</color>
-    <color name="black_overlay">#40000000</color>
+    <color name="black_overlay">#60000000</color>
     <color name="white_overlay">#40FFFFFF</color>
 </resources>


### PR DESCRIPTION
Add basic slide from bottom animations to dialog. User is also able to add custom animations using builder.
The view is inflated not on top of the decor view because by doing like that the dialog is actually overlapping also the soft keys in case of nexus devices. Now it's overlapping only the content but ActionBar is still on top. By the way, with toolbar it should work correctly.

Next step are:
- Intercept back pressed from Activity (Not sure if we are able to do that).
- Overlay action bar with dialog.