### PR TITLE
Fix dialog list to take all available width

### DIFF
--- a/dialogplus/src/main/res/layout/dialog_list.xml
+++ b/dialogplus/src/main/res/layout/dialog_list.xml
@@ -8,7 +8,7 @@
 
     <ListView
         android:id="@+id/list"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_gravity="bottom"
         android:divider="@null"


### PR DESCRIPTION
Otherwise, list items, header/footer don't take all available space for listview when measured