### PR TITLE
Support composite gravities

### DIFF
--- a/dialogplus/src/main/java/com/orhanobut/dialogplus/Utils.java
+++ b/dialogplus/src/main/java/com/orhanobut/dialogplus/Utils.java
@@ -62,12 +62,12 @@ final class Utils {
   static int getAnimationResource(int gravity, boolean isInAnimation) {
     if ((gravity & Gravity.TOP) == Gravity.TOP) {
       return isInAnimation ? R.anim.slide_in_top : R.anim.slide_out_top;
-    } else if ((gravity & Gravity.BOTTOM) == Gravity.BOTTOM) {
+    }
+    if ((gravity & Gravity.BOTTOM) == Gravity.BOTTOM) {
       return isInAnimation ? R.anim.slide_in_bottom : R.anim.slide_out_bottom;
-    } else if ((gravity & Gravity.CENTER) == Gravity.CENTER) {
+    }
+    if ((gravity & Gravity.CENTER) == Gravity.CENTER) {
       return isInAnimation ? R.anim.fade_in_center : R.anim.fade_out_center;
-    } else {
-      // This case is not implemented because we don't expect any other gravity at the moment
     }
     return INVALID;
   }

--- a/dialogplus/src/main/java/com/orhanobut/dialogplus/Utils.java
+++ b/dialogplus/src/main/java/com/orhanobut/dialogplus/Utils.java
@@ -60,15 +60,14 @@ final class Utils {
    * @return the id of the animation resource
    */
   static int getAnimationResource(int gravity, boolean isInAnimation) {
-    switch (gravity) {
-      case Gravity.TOP:
-        return isInAnimation ? R.anim.slide_in_top : R.anim.slide_out_top;
-      case Gravity.BOTTOM:
-        return isInAnimation ? R.anim.slide_in_bottom : R.anim.slide_out_bottom;
-      case Gravity.CENTER:
-        return isInAnimation ? R.anim.fade_in_center : R.anim.fade_out_center;
-      default:
-        // This case is not implemented because we don't expect any other gravity at the moment
+    if ((gravity & Gravity.TOP) == Gravity.TOP) {
+      return isInAnimation ? R.anim.slide_in_top : R.anim.slide_out_top;
+    } else if ((gravity & Gravity.BOTTOM) == Gravity.BOTTOM) {
+      return isInAnimation ? R.anim.slide_in_bottom : R.anim.slide_out_bottom;
+    } else if ((gravity & Gravity.CENTER) == Gravity.CENTER) {
+      return isInAnimation ? R.anim.fade_in_center : R.anim.fade_out_center;
+    } else {
+      // This case is not implemented because we don't expect any other gravity at the moment
     }
     return INVALID;
   }


### PR DESCRIPTION
Instead of requiring gravity to be set as just a simple value, e.g.
Gravity.BOTTOM, allow composite ones which are based on TOP, BOTTOM and
CENTER such as BOTTOM | CENTER_HORIZONTAL. This is achieved by a bitwise
check.