### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Simple and advanced dialog solution.
 
 ### Gradle
 ```groovy
-compile 'com.orhanobut:dialogplus:1.11@aar'
+implementation 'com.orhanobut:dialogplus:1.11@aar'
 ```
 
 ### Usage


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.